### PR TITLE
fix: window dragging not working

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "shell:allow-open",
     "store:default",
     "os:default",

--- a/src-tauri/gen/schemas/capabilities.json
+++ b/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Capability for the main window","local":true,"windows":["main"],"permissions":["core:default","shell:allow-open","store:default","os:default","updater:default"]}}
+{"default":{"identifier":"default","description":"Capability for the main window","local":true,"windows":["main"],"permissions":["core:default","core:window:allow-start-dragging","shell:allow-open","store:default","os:default","updater:default"]}}

--- a/src/components/navigation/TabBar.tsx
+++ b/src/components/navigation/TabBar.tsx
@@ -109,7 +109,7 @@ export function TabBar() {
   }, [routerState.location.pathname, drive, revealPath, setHighlight, expand]);
 
   return (
-    <div className="flex h-9 shrink-0 items-stretch border-b border-border bg-bg-secondary">
+    <div className="flex h-9 shrink-0 items-stretch border-b border-border bg-bg-secondary" data-tauri-drag-region>
       {/* Back / Forward */}
       <div className="flex shrink-0 items-center gap-0.5 border-r border-border px-1.5">
         <button

--- a/src/components/navigation/TabBar.tsx
+++ b/src/components/navigation/TabBar.tsx
@@ -130,9 +130,10 @@ export function TabBar() {
         </button>
       </div>
 
-      {/* Tab list */}
+      {/* Tab list — drag-region so empty space between tabs is draggable */}
       <div
         ref={scrollRef}
+        data-tauri-drag-region
         className="flex min-w-0 flex-1 items-stretch overflow-x-auto scrollbar-none"
         style={{ scrollbarWidth: "none" }}
       >

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -64,12 +64,6 @@ function RootLayout() {
         theme === "system" && typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : ""
       }`}
     >
-      {/* Window drag region — thin bar at very top */}
-      <div
-        data-tauri-drag-region
-        className="absolute left-0 right-0 top-0 z-50 h-3"
-        style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-      />
       <AuthGuard>
         <ApiProvider>
           <Sidebar onOpenCommandPalette={() => setCmdkOpen(true)} />


### PR DESCRIPTION
## Summary

Fixes #1 — window dragging was completely broken.

**Root cause:** `core:window:allow-start-dragging` was missing from the Tauri capabilities. Without this permission, Tauri silently ignores all `data-tauri-drag-region` attributes — no matter where you place them.

**Changes:**
- Added `core:window:allow-start-dragging` to `src-tauri/capabilities/default.json`
- Removed the invisible 12px absolute overlay drag strip from `__root.tsx` (it blocked clicks on elements beneath it and was too small to grab)
- Applied `data-tauri-drag-region` directly to the `TabBar` component and its tab scroll area — empty space between/after tabs is now draggable
- Sidebar header already had `data-tauri-drag-region` set

## Test plan

- [x] `npm run build` passes
- [x] Window is draggable from tab bar (empty space between/after tabs)
- [x] Window is draggable from sidebar header
- [x] All buttons in the tab bar remain clickable (back, forward, tabs, close, new tab)
- [x] Traffic lights (close/minimize/maximize) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)